### PR TITLE
Cursor Style for Children Only items

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,15 +1,17 @@
-.multi-menu-item.has-children:after, .multi-select-menu-expand-icon:before, .multi-menu-overflow-icon {
-  content: '';
+.multi-menu-item.has-children:after,
+.multi-select-menu-expand-icon:before,
+.multi-menu-overflow-icon {
+  content: "";
   display: block;
   width: 12px;
   height: 12px;
   mask-type: alpha;
   -webkit-mask-repeat: no-repeat;
-          mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
   -webkit-mask-position: center;
-          mask-position: center;
-  -webkit-mask-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB3aWR0aD0iN3B4IiBoZWlnaHQ9IjEycHgiIHZpZXdCb3g9IjAgMCA3IDEyIiB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiPgogICAgPCEtLSBHZW5lcmF0b3I6IFNrZXRjaCA0Ny4xICg0NTQyMikgLSBodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2ggLS0+CiAgICA8dGl0bGU+UGF0aCAxMTwvdGl0bGU+CiAgICA8ZGVzYz5DcmVhdGVkIHdpdGggU2tldGNoLjwvZGVzYz4KICAgIDxkZWZzPjwvZGVmcz4KICAgIDxnIGlkPSJQYWdlLTEiIHN0cm9rZT0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIxIiBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiPgogICAgICAgIDxnIGlkPSJEZXNrdG9wLUhEIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtMTIyNS4wMDAwMDAsIC00MDQuMDAwMDAwKSIgc3Ryb2tlPSIjRkZGRkZGIj4KICAgICAgICAgICAgPGcgaWQ9IkFkZC1EYXRhLU1lbnUiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDEwMjAuMDAwMDAwLCAzNzYuMDAwMDAwKSI+CiAgICAgICAgICAgICAgICA8ZyBpZD0iQ3VycmVudC1Vc2VyLUhPdmVyIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgwLjAwMDAwMCwgMTkuMDAwMDAwKSI+CiAgICAgICAgICAgICAgICAgICAgPHBvbHlsaW5lIGlkPSJQYXRoLTExIiBwb2ludHM9IjIwNiAxMCAyMTEuMjUwNDA3IDE1LjE4NDY1ODQgMjA2IDIwLjQzNTA2NSI+PC9wb2x5bGluZT4KICAgICAgICAgICAgICAgIDwvZz4KICAgICAgICAgICAgPC9nPgogICAgICAgIDwvZz4KICAgIDwvZz4KPC9zdmc+');
-          mask-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB3aWR0aD0iN3B4IiBoZWlnaHQ9IjEycHgiIHZpZXdCb3g9IjAgMCA3IDEyIiB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiPgogICAgPCEtLSBHZW5lcmF0b3I6IFNrZXRjaCA0Ny4xICg0NTQyMikgLSBodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2ggLS0+CiAgICA8dGl0bGU+UGF0aCAxMTwvdGl0bGU+CiAgICA8ZGVzYz5DcmVhdGVkIHdpdGggU2tldGNoLjwvZGVzYz4KICAgIDxkZWZzPjwvZGVmcz4KICAgIDxnIGlkPSJQYWdlLTEiIHN0cm9rZT0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIxIiBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiPgogICAgICAgIDxnIGlkPSJEZXNrdG9wLUhEIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtMTIyNS4wMDAwMDAsIC00MDQuMDAwMDAwKSIgc3Ryb2tlPSIjRkZGRkZGIj4KICAgICAgICAgICAgPGcgaWQ9IkFkZC1EYXRhLU1lbnUiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDEwMjAuMDAwMDAwLCAzNzYuMDAwMDAwKSI+CiAgICAgICAgICAgICAgICA8ZyBpZD0iQ3VycmVudC1Vc2VyLUhPdmVyIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgwLjAwMDAwMCwgMTkuMDAwMDAwKSI+CiAgICAgICAgICAgICAgICAgICAgPHBvbHlsaW5lIGlkPSJQYXRoLTExIiBwb2ludHM9IjIwNiAxMCAyMTEuMjUwNDA3IDE1LjE4NDY1ODQgMjA2IDIwLjQzNTA2NSI+PC9wb2x5bGluZT4KICAgICAgICAgICAgICAgIDwvZz4KICAgICAgICAgICAgPC9nPgogICAgICAgIDwvZz4KICAgIDwvZz4KPC9zdmc+');
+  mask-position: center;
+  -webkit-mask-image: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB3aWR0aD0iN3B4IiBoZWlnaHQ9IjEycHgiIHZpZXdCb3g9IjAgMCA3IDEyIiB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiPgogICAgPCEtLSBHZW5lcmF0b3I6IFNrZXRjaCA0Ny4xICg0NTQyMikgLSBodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2ggLS0+CiAgICA8dGl0bGU+UGF0aCAxMTwvdGl0bGU+CiAgICA8ZGVzYz5DcmVhdGVkIHdpdGggU2tldGNoLjwvZGVzYz4KICAgIDxkZWZzPjwvZGVmcz4KICAgIDxnIGlkPSJQYWdlLTEiIHN0cm9rZT0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIxIiBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiPgogICAgICAgIDxnIGlkPSJEZXNrdG9wLUhEIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtMTIyNS4wMDAwMDAsIC00MDQuMDAwMDAwKSIgc3Ryb2tlPSIjRkZGRkZGIj4KICAgICAgICAgICAgPGcgaWQ9IkFkZC1EYXRhLU1lbnUiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDEwMjAuMDAwMDAwLCAzNzYuMDAwMDAwKSI+CiAgICAgICAgICAgICAgICA8ZyBpZD0iQ3VycmVudC1Vc2VyLUhPdmVyIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgwLjAwMDAwMCwgMTkuMDAwMDAwKSI+CiAgICAgICAgICAgICAgICAgICAgPHBvbHlsaW5lIGlkPSJQYXRoLTExIiBwb2ludHM9IjIwNiAxMCAyMTEuMjUwNDA3IDE1LjE4NDY1ODQgMjA2IDIwLjQzNTA2NSI+PC9wb2x5bGluZT4KICAgICAgICAgICAgICAgIDwvZz4KICAgICAgICAgICAgPC9nPgogICAgICAgIDwvZz4KICAgIDwvZz4KPC9zdmc+");
+  mask-image: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB3aWR0aD0iN3B4IiBoZWlnaHQ9IjEycHgiIHZpZXdCb3g9IjAgMCA3IDEyIiB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiPgogICAgPCEtLSBHZW5lcmF0b3I6IFNrZXRjaCA0Ny4xICg0NTQyMikgLSBodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2ggLS0+CiAgICA8dGl0bGU+UGF0aCAxMTwvdGl0bGU+CiAgICA8ZGVzYz5DcmVhdGVkIHdpdGggU2tldGNoLjwvZGVzYz4KICAgIDxkZWZzPjwvZGVmcz4KICAgIDxnIGlkPSJQYWdlLTEiIHN0cm9rZT0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIxIiBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiPgogICAgICAgIDxnIGlkPSJEZXNrdG9wLUhEIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtMTIyNS4wMDAwMDAsIC00MDQuMDAwMDAwKSIgc3Ryb2tlPSIjRkZGRkZGIj4KICAgICAgICAgICAgPGcgaWQ9IkFkZC1EYXRhLU1lbnUiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDEwMjAuMDAwMDAwLCAzNzYuMDAwMDAwKSI+CiAgICAgICAgICAgICAgICA8ZyBpZD0iQ3VycmVudC1Vc2VyLUhPdmVyIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgwLjAwMDAwMCwgMTkuMDAwMDAwKSI+CiAgICAgICAgICAgICAgICAgICAgPHBvbHlsaW5lIGlkPSJQYXRoLTExIiBwb2ludHM9IjIwNiAxMCAyMTEuMjUwNDA3IDE1LjE4NDY1ODQgMjA2IDIwLjQzNTA2NSI+PC9wb2x5bGluZT4KICAgICAgICAgICAgICAgIDwvZz4KICAgICAgICAgICAgPC9nPgogICAgICAgIDwvZz4KICAgIDwvZz4KPC9zdmc+");
   background: #9a9a9a;
   position: absolute;
   right: 6px;
@@ -18,9 +20,10 @@
   margin-top: -6px;
 }
 
-.multi-menu, .multi-menu * {
+.multi-menu,
+.multi-menu * {
   -webkit-box-sizing: border-box;
-          box-sizing: border-box;
+  box-sizing: border-box;
 }
 
 .multi-menu {
@@ -31,9 +34,9 @@
   text-align: left;
   font-size: 1em;
   -webkit-user-select: none;
-     -moz-user-select: none;
-      -ms-user-select: none;
-          user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   position: relative;
   overflow: hidden;
 }
@@ -53,11 +56,11 @@
   display: -ms-flexbox;
   display: flex;
   -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
+  -ms-flex-align: center;
+  align-items: center;
   -webkit-box-pack: center;
-      -ms-flex-pack: center;
-          justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .multi-menu-overflow-up {
@@ -72,12 +75,12 @@
   position: static;
   margin: 0;
   -webkit-transform: rotate(90deg);
-          transform: rotate(90deg);
+  transform: rotate(90deg);
 }
 
 .multi-menu-overflow-up .multi-menu-overflow-icon {
   -webkit-transform: rotate(-90deg);
-          transform: rotate(-90deg);
+  transform: rotate(-90deg);
 }
 
 .multi-menu-inner-wrapper {
@@ -85,51 +88,58 @@
   width: 180px;
 }
 
-.multi-menu, .multi-select-menu.expanded {
-  -webkit-box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.07), 0 4px 12px rgba(0, 0, 0, 0.2);
-          box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.07), 0 4px 12px rgba(0, 0, 0, 0.2);
+.multi-menu,
+.multi-select-menu.expanded {
+  -webkit-box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.07),
+    0 4px 12px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.07), 0 4px 12px rgba(0, 0, 0, 0.2);
 }
 
 .multi-menu-wrapper-attached.expand-up .multi-menu {
-  -webkit-box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.07), -4px 2px 6px rgba(0, 0, 0, 0.07), 4px 2px 6px rgba(0, 0, 0, 0.07);
-          box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.07), -4px 2px 6px rgba(0, 0, 0, 0.07), 4px 2px 6px rgba(0, 0, 0, 0.07);
+  -webkit-box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.07),
+    -4px 2px 6px rgba(0, 0, 0, 0.07), 4px 2px 6px rgba(0, 0, 0, 0.07);
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.07), -4px 2px 6px rgba(0, 0, 0, 0.07),
+    4px 2px 6px rgba(0, 0, 0, 0.07);
 }
 
 .multi-menu-item {
   position: relative;
   padding-right: 20px;
   -webkit-user-select: none;
-     -moz-user-select: none;
-      -ms-user-select: none;
-          user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
   -webkit-box-orient: vertical;
   -webkit-box-direction: normal;
-      -ms-flex-direction: column;
-          flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
   -webkit-box-align: stretch;
-      -ms-flex-align: stretch;
-          align-items: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
   -webkit-box-pack: center;
-      -ms-flex-pack: center;
-          justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
   cursor: pointer;
 }
 
-.multi-menu-item.open, .multi-menu-item:hover {
+.multi-menu-item.open,
+.multi-menu-item:hover {
   background: #07f;
-  color: #fff
+  color: #fff;
 }
 
-.multi-menu-item.open.has-children:after, .multi-menu-item:hover.has-children:after {
+.multi-menu-item.open.has-children:after,
+.multi-menu-item:hover.has-children:after {
   background: #fff;
 }
 
-.multi-menu-item.open > .multi-menu-item-label > .multi-menu-item-subtitle, .multi-menu-item:hover > .multi-menu-item-label > .multi-menu-item-subtitle {
-      color: #fff;
-    }
+.multi-menu-item.open > .multi-menu-item-label > .multi-menu-item-subtitle,
+.multi-menu-item:hover > .multi-menu-item-label > .multi-menu-item-subtitle {
+  color: #fff;
+}
 
 .multi-menu-item.disabled {
   color: #9a9a9a;
@@ -144,28 +154,29 @@
 }
 
 .multi-menu-item-label > .multi-menu-item-subtitle {
-    font-size: 0.8em;
-    color: #959595;
-    margin-left: 0.5em;
-  }
+  font-size: 0.8em;
+  color: #959595;
+  margin-left: 0.5em;
+}
 
 .multi-menu-item.inline .multi-menu-item-label {
   font-size: 0.8em;
 }
 
+.multi-menu-item.children-only,
 .multi-menu-item.children-only > .multi-menu-item-label {
   cursor: default;
 }
 
 .multi-select-menu-expand-icon:before {
   -webkit-transform: rotate(90deg);
-          transform: rotate(90deg);
+  transform: rotate(90deg);
   right: 12px;
 }
 
 .multi-menu-trigger.expanded .multi-select-menu-expand-icon:before {
   -webkit-transform: rotate(270deg);
-          transform: rotate(270deg);
+  transform: rotate(270deg);
 }
 
 .multi-menu-child {
@@ -191,13 +202,14 @@
 .multi-menu-trigger {
   position: relative;
   -webkit-user-select: none;
-     -moz-user-select: none;
-      -ms-user-select: none;
-          user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
-.multi-menu-trigger.expanded:before, .multi-menu-trigger.expanded:after {
-  content: '';
+.multi-menu-trigger.expanded:before,
+.multi-menu-trigger.expanded:after {
+  content: "";
   display: block;
   position: absolute;
   left: 50%;
@@ -217,7 +229,8 @@
   margin-left: -6px;
 }
 
-.multi-menu-trigger.expand-up.expanded:before, .multi-menu-trigger.expand-up.expanded:after {
+.multi-menu-trigger.expand-up.expanded:before,
+.multi-menu-trigger.expand-up.expanded:after {
   display: none;
 }
 
@@ -262,7 +275,8 @@
   height: calc(1.2em + 20px);
 }
 
-.multi-select-menu.multi-menu-trigger.expanded:before, .multi-select-menu.multi-menu-trigger.expanded:after {
+.multi-select-menu.multi-menu-trigger.expanded:before,
+.multi-select-menu.multi-menu-trigger.expanded:after {
   display: none;
 }
 
@@ -273,7 +287,7 @@
   border-radius: 6px;
   position: relative;
   -webkit-box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
-          box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
   line-height: 1.2em;
   position: absolute;
   left: 0;
@@ -283,7 +297,7 @@
 
 .multi-select-menu.expanded .multi-select-menu-selection {
   -webkit-box-shadow: none;
-          box-shadow: none;
+  box-shadow: none;
 }
 
 .multi-select-menu-value {
@@ -294,10 +308,10 @@
 }
 
 .multi-select-menu-value .multi-select-menu-value-subtitle {
-    font-size: 0.8em;
-    color: #959595;
-    margin-left: 0.5em;
-  }
+  font-size: 0.8em;
+  color: #959595;
+  margin-left: 0.5em;
+}
 
 .multi-select-menu.expand-down.expanded .multi-select-menu-selection {
   border-bottom-left-radius: 0;
@@ -309,20 +323,24 @@
   border-top-right-radius: 0;
 }
 
-.multi-menu-wrapper-attached.expand-down > .multi-menu-inner-wrapper > .multi-menu {
+.multi-menu-wrapper-attached.expand-down
+  > .multi-menu-inner-wrapper
+  > .multi-menu {
   border-top-left-radius: 0;
   border-top-right-radius: 0;
   margin-top: -1px;
 }
 
-.multi-menu-wrapper-attached.expand-up > .multi-menu-inner-wrapper > .multi-menu {
+.multi-menu-wrapper-attached.expand-up
+  > .multi-menu-inner-wrapper
+  > .multi-menu {
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
   margin-bottom: -1px;
 }
 
 .multi-menu-wrapper-attached > .multi-menu-inner-wrapper:before {
-  content: '';
+  content: "";
   display: block;
   position: absolute;
   top: -4px;
@@ -343,13 +361,13 @@
   display: none;
 }
 
-.multi-select-menu-placeholder, .multi-menu-empty {
+.multi-select-menu-placeholder,
+.multi-menu-empty {
   color: #9a9a9a;
 }
 
 .multi-menu-empty {
   padding: 0 12px;
 }
-
 
 /*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInNyYy9zdHlsZXMvc3R5bGVzLmNzcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQTtFQUNFLFlBQVk7RUFDWixlQUFlO0VBQ2YsWUFBWTtFQUNaLGFBQWE7RUFDYixpQkFBaUI7RUFDakIsK0JBQXVCO1VBQXZCLHVCQUF1QjtFQUN2Qiw4QkFBc0I7VUFBdEIsc0JBQXNCO0VBQ3RCLDByQ0FBa3JDO1VBQWxyQyxrckNBQWtyQztFQUNsckMsb0JBQW9CO0VBQ3BCLG1CQUFtQjtFQUNuQixXQUFXO0VBQ1gsa0JBQWtCO0VBQ2xCLFNBQVM7RUFDVCxpQkFBaUI7Q0FDbEI7O0FBRUQ7RUFDRSwrQkFBdUI7VUFBdkIsdUJBQXVCO0NBQ3hCOztBQUVEO0VBQ0UsYUFBYTtFQUNiLG9CQUFvQjtFQUNwQixtQkFBbUI7RUFDbkIsWUFBWTtFQUNaLGlCQUFpQjtFQUNqQixlQUFlO0VBQ2YsMEJBQWtCO0tBQWxCLHVCQUFrQjtNQUFsQixzQkFBa0I7VUFBbEIsa0JBQWtCO0VBQ2xCLG1CQUFtQjtFQUNuQixpQkFBaUI7Q0FDbEI7O0FBRUQ7RUFDRSxlQUFlO0VBQ2YsaUJBQWlCO0NBQ2xCOztBQUVEO0VBQ0UsbUJBQW1CO0VBQ25CLFFBQVE7RUFDUixTQUFTO0VBQ1QsYUFBYTtFQUNiLG9CQUFvQjtFQUNwQixxQkFBYztFQUFkLHFCQUFjO0VBQWQsY0FBYztFQUNkLDBCQUFvQjtNQUFwQix1QkFBb0I7VUFBcEIsb0JBQW9CO0VBQ3BCLHlCQUF3QjtNQUF4QixzQkFBd0I7VUFBeEIsd0JBQXdCO0NBQ3pCOztBQUVEO0VBQ0UsT0FBTztDQUNSOztBQUVEO0VBQ0UsVUFBVTtDQUNYOztBQUVEO0VBQ0UsaUJBQWlCO0VBQ2pCLFVBQVU7RUFDVixpQ0FBeUI7VUFBekIseUJBQXlCO0NBQzFCOztBQUVEO0VBQ0Usa0NBQTBCO1VBQTFCLDBCQUEwQjtDQUMzQjs7QUFFRDtFQUNFLG1CQUFtQjtFQUNuQixhQUFhO0NBQ2Q7O0FBRUQ7RUFDRSxpRkFBeUU7VUFBekUseUVBQXlFO0NBQzFFOztBQUVEO0VBQ0UscUhBQTZHO1VBQTdHLDZHQUE2RztDQUM5Rzs7QUFFRDtFQUNFLG1CQUFtQjtFQUNuQixvQkFBb0I7RUFDcEIsMEJBQWtCO0tBQWxCLHVCQUFrQjtNQUFsQixzQkFBa0I7VUFBbEIsa0JBQWtCO0VBQ2xCLHFCQUFjO0VBQWQscUJBQWM7RUFBZCxjQUFjO0VBQ2QsNkJBQXVCO0VBQXZCLDhCQUF1QjtNQUF2QiwyQkFBdUI7VUFBdkIsdUJBQXVCO0VBQ3ZCLDJCQUFxQjtNQUFyQix3QkFBcUI7VUFBckIscUJBQXFCO0VBQ3JCLHlCQUF3QjtNQUF4QixzQkFBd0I7VUFBeEIsd0JBQXdCO0VBQ3hCLGdCQUFnQjtDQUNqQjs7QUFFRDtFQUNFLGlCQUFpQjtFQUNqQixXQUFZO0NBV2I7O0FBVEM7RUFDRSxpQkFBaUI7Q0FDbEI7O0FBR0M7TUFDRSxZQUFZO0tBQ2I7O0FBSUw7RUFDRSxlQUFlO0VBQ2YscUJBQXFCO0NBQ3RCOztBQUVEO0VBQ0Usb0JBQW9CO0VBQ3BCLGlCQUFpQjtFQUNqQix3QkFBd0I7RUFDeEIsb0JBQW9CO0NBT3JCOztBQUxDO0lBQ0UsaUJBQWlCO0lBQ2pCLGVBQWU7SUFDZixtQkFBbUI7R0FDcEI7O0FBR0g7RUFDRSxpQkFBaUI7Q0FDbEI7O0FBRUQ7RUFDRSxnQkFBZ0I7Q0FDakI7O0FBRUQ7RUFDRSxpQ0FBeUI7VUFBekIseUJBQXlCO0VBQ3pCLFlBQVk7Q0FDYjs7QUFFRDtFQUNFLGtDQUEwQjtVQUExQiwwQkFBMEI7Q0FDM0I7O0FBRUQ7RUFDRSxtQkFBbUI7RUFDbkIsV0FBVztFQUNYLGlCQUFpQjtFQUNqQixPQUFPO0VBQ1AsaUJBQWlCO0NBQ2xCOztBQUVEO0VBQ0UsWUFBWTtFQUNaLFdBQVc7RUFDWCxrQkFBa0I7RUFDbEIsZUFBZTtDQUNoQjs7QUFFRDtFQUNFLGdCQUFnQjtFQUNoQixtQkFBbUI7Q0FDcEI7O0FBRUQ7RUFDRSxtQkFBbUI7RUFDbkIsMEJBQWtCO0tBQWxCLHVCQUFrQjtNQUFsQixzQkFBa0I7VUFBbEIsa0JBQWtCO0NBQ25COztBQUVEO0VBRUUsWUFBWTtFQUNaLGVBQWU7RUFDZixtQkFBbUI7RUFDbkIsVUFBVTtFQUNWLFVBQVU7RUFDVixnQkFBZ0I7RUFDaEIsa0JBQWtCO0VBQ2xCLDhCQUE4QjtFQUM5QixpQkFBaUI7RUFDakIsNkJBQTZCO0VBQzdCLGVBQWU7Q0FDaEI7O0FBRUQ7RUFDRSxrQkFBa0I7RUFDbEIseUNBQXlDO0VBQ3pDLGdCQUFnQjtFQUNoQixrQkFBa0I7Q0FDbkI7O0FBRUQ7RUFFRSxjQUFjO0NBQ2Y7O0FBRUQ7RUFDRSxnQkFBZ0I7RUFDaEIsZUFBZTtDQUNoQjs7QUFFRDtFQUNFLGdCQUFnQjtFQUNoQixlQUFlO0VBQ2YsUUFBUTtFQUNSLFNBQVM7RUFDVCxPQUFPO0VBQ1AsVUFBVTtDQUNYOztBQUVEO0VBQ0UsZUFBZTtDQUNoQjs7QUFFRDtFQUNFLFFBQVE7Q0FDVDs7QUFFRDtFQUNFLFNBQVM7Q0FDVjs7QUFFRDtFQUNFLFVBQVU7RUFDVixtQkFBbUI7Q0FDcEI7O0FBRUQ7RUFDRSxlQUFlO0VBQ2YseUNBQXlDO0NBQzFDOztBQUVEO0VBQ0UsbUJBQW1CO0VBQ25CLDJCQUEyQjtDQUM1Qjs7QUFFRDtFQUVFLGNBQWM7Q0FDZjs7QUFFRDtFQUNFLG9CQUFvQjtFQUNwQixZQUFZO0VBQ1osNkJBQTZCO0VBQzdCLG1CQUFtQjtFQUNuQixtQkFBbUI7RUFDbkIsdURBQStDO1VBQS9DLCtDQUErQztFQUMvQyxtQkFBbUI7RUFDbkIsbUJBQW1CO0VBQ25CLFFBQVE7RUFDUixTQUFTO0VBQ1QsT0FBTztDQUNSOztBQUVEO0VBQ0UseUJBQWlCO1VBQWpCLGlCQUFpQjtDQUNsQjs7QUFFRDtFQUNFLGVBQWU7RUFDZixvQkFBb0I7RUFDcEIsaUJBQWlCO0VBQ2pCLHdCQUF3QjtDQU96Qjs7QUFMQztJQUNFLGlCQUFpQjtJQUNqQixlQUFlO0lBQ2YsbUJBQW1CO0dBQ3BCOztBQUdIO0VBQ0UsNkJBQTZCO0VBQzdCLDhCQUE4QjtDQUMvQjs7QUFFRDtFQUNFLDBCQUEwQjtFQUMxQiwyQkFBMkI7Q0FDNUI7O0FBRUQ7RUFDRSwwQkFBMEI7RUFDMUIsMkJBQTJCO0VBQzNCLGlCQUFpQjtDQUNsQjs7QUFFRDtFQUNFLDZCQUE2QjtFQUM3Qiw4QkFBOEI7RUFDOUIsb0JBQW9CO0NBQ3JCOztBQUVEO0VBQ0UsWUFBWTtFQUNaLGVBQWU7RUFDZixtQkFBbUI7RUFDbkIsVUFBVTtFQUNWLFFBQVE7RUFDUixTQUFTO0VBQ1QsWUFBWTtFQUNaLG9CQUFvQjtFQUNwQixXQUFXO0NBQ1o7O0FBRUQ7RUFDRSxVQUFVO0VBQ1YsYUFBYTtFQUNiLFlBQVk7Q0FDYjs7QUFFRDtFQUNFLGNBQWM7Q0FDZjs7QUFFRDtFQUNFLGVBQWU7Q0FDaEI7O0FBRUQ7RUFDRSxnQkFBZ0I7Q0FDakIiLCJmaWxlIjoic3R5bGVzLmNzcyIsInNvdXJjZXNDb250ZW50IjpbIi5tdWx0aS1tZW51LWl0ZW0uaGFzLWNoaWxkcmVuOmFmdGVyLCAubXVsdGktc2VsZWN0LW1lbnUtZXhwYW5kLWljb246YmVmb3JlLCAubXVsdGktbWVudS1vdmVyZmxvdy1pY29uIHtcbiAgY29udGVudDogJyc7XG4gIGRpc3BsYXk6IGJsb2NrO1xuICB3aWR0aDogMTJweDtcbiAgaGVpZ2h0OiAxMnB4O1xuICBtYXNrLXR5cGU6IGFscGhhO1xuICBtYXNrLXJlcGVhdDogbm8tcmVwZWF0O1xuICBtYXNrLXBvc2l0aW9uOiBjZW50ZXI7XG4gIG1hc2staW1hZ2U6IHVybCgnZGF0YTppbWFnZS9zdmcreG1sO2Jhc2U2NCxQRDk0Yld3Z2RtVnljMmx2YmowaU1TNHdJaUJsYm1OdlpHbHVaejBpVlZSR0xUZ2lQejRLUEhOMlp5QjNhV1IwYUQwaU4zQjRJaUJvWldsbmFIUTlJakV5Y0hnaUlIWnBaWGRDYjNnOUlqQWdNQ0EzSURFeUlpQjJaWEp6YVc5dVBTSXhMakVpSUhodGJHNXpQU0pvZEhSd09pOHZkM2QzTG5jekxtOXlaeTh5TURBd0wzTjJaeUlnZUcxc2JuTTZlR3hwYm1zOUltaDBkSEE2THk5M2QzY3Vkek11YjNKbkx6RTVPVGt2ZUd4cGJtc2lQZ29nSUNBZ1BDRXRMU0JIWlc1bGNtRjBiM0k2SUZOclpYUmphQ0EwTnk0eElDZzBOVFF5TWlrZ0xTQm9kSFJ3T2k4dmQzZDNMbUp2YUdWdGFXRnVZMjlrYVc1bkxtTnZiUzl6YTJWMFkyZ2dMUzArQ2lBZ0lDQThkR2wwYkdVK1VHRjBhQ0F4TVR3dmRHbDBiR1UrQ2lBZ0lDQThaR1Z6WXo1RGNtVmhkR1ZrSUhkcGRHZ2dVMnRsZEdOb0xqd3ZaR1Z6WXo0S0lDQWdJRHhrWldaelBqd3ZaR1ZtY3o0S0lDQWdJRHhuSUdsa1BTSlFZV2RsTFRFaUlITjBjbTlyWlQwaWJtOXVaU0lnYzNSeWIydGxMWGRwWkhSb1BTSXhJaUJtYVd4c1BTSnViMjVsSWlCbWFXeHNMWEoxYkdVOUltVjJaVzV2WkdRaVBnb2dJQ0FnSUNBZ0lEeG5JR2xrUFNKRVpYTnJkRzl3TFVoRUlpQjBjbUZ1YzJadmNtMDlJblJ5WVc1emJHRjBaU2d0TVRJeU5TNHdNREF3TURBc0lDMDBNRFF1TURBd01EQXdLU0lnYzNSeWIydGxQU0lqUmtaR1JrWkdJajRLSUNBZ0lDQWdJQ0FnSUNBZ1BHY2dhV1E5SWtGa1pDMUVZWFJoTFUxbGJuVWlJSFJ5WVc1elptOXliVDBpZEhKaGJuTnNZWFJsS0RFd01qQXVNREF3TURBd0xDQXpOell1TURBd01EQXdLU0krQ2lBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0E4WnlCcFpEMGlRM1Z5Y21WdWRDMVZjMlZ5TFVoUGRtVnlJaUIwY21GdWMyWnZjbTA5SW5SeVlXNXpiR0YwWlNnd0xqQXdNREF3TUN3Z01Ua3VNREF3TURBd0tTSStDaUFnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnUEhCdmJIbHNhVzVsSUdsa1BTSlFZWFJvTFRFeElpQndiMmx1ZEhNOUlqSXdOaUF4TUNBeU1URXVNalV3TkRBM0lERTFMakU0TkRZMU9EUWdNakEySURJd0xqUXpOVEEyTlNJK1BDOXdiMng1YkdsdVpUNEtJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lEd3ZaejRLSUNBZ0lDQWdJQ0FnSUNBZ1BDOW5QZ29nSUNBZ0lDQWdJRHd2Wno0S0lDQWdJRHd2Wno0S1BDOXpkbWMrJyk7XG4gIGJhY2tncm91bmQ6ICM5YTlhOWE7XG4gIHBvc2l0aW9uOiBhYnNvbHV0ZTtcbiAgcmlnaHQ6IDZweDtcbiAgbGluZS1oZWlnaHQ6IDEycHg7XG4gIHRvcDogNTAlO1xuICBtYXJnaW4tdG9wOiAtNnB4O1xufVxuXG4ubXVsdGktbWVudSwgLm11bHRpLW1lbnUgKiB7XG4gIGJveC1zaXppbmc6IGJvcmRlci1ib3g7XG59XG5cbi5tdWx0aS1tZW51IHtcbiAgd2lkdGg6IDE4MHB4O1xuICBiYWNrZ3JvdW5kOiAjZjVmNWY1O1xuICBib3JkZXItcmFkaXVzOiA2cHg7XG4gIGNvbG9yOiAjNDQ0O1xuICB0ZXh0LWFsaWduOiBsZWZ0O1xuICBmb250LXNpemU6IDFlbTtcbiAgdXNlci1zZWxlY3Q6IG5vbmU7XG4gIHBvc2l0aW9uOiByZWxhdGl2ZTtcbiAgb3ZlcmZsb3c6IGhpZGRlbjtcbn1cblxuLm11bHRpLW1lbnUtc2Nyb2xsLWNvbnRhaW5lciB7XG4gIHBhZGRpbmc6IDhweCAwO1xuICBvdmVyZmxvdy15OiBhdXRvO1xufVxuXG4ubXVsdGktbWVudS1vdmVyZmxvdyB7XG4gIHBvc2l0aW9uOiBhYnNvbHV0ZTtcbiAgbGVmdDogMDtcbiAgcmlnaHQ6IDA7XG4gIGhlaWdodDogMTRweDtcbiAgYmFja2dyb3VuZDogI2Y1ZjVmNTtcbiAgZGlzcGxheTogZmxleDtcbiAgYWxpZ24taXRlbXM6IGNlbnRlcjtcbiAganVzdGlmeS1jb250ZW50OiBjZW50ZXI7XG59XG5cbi5tdWx0aS1tZW51LW92ZXJmbG93LXVwIHtcbiAgdG9wOiAwO1xufVxuXG4ubXVsdGktbWVudS1vdmVyZmxvdy1kb3duIHtcbiAgYm90dG9tOiAwO1xufVxuXG4ubXVsdGktbWVudS1vdmVyZmxvdy1pY29uIHtcbiAgcG9zaXRpb246IHN0YXRpYztcbiAgbWFyZ2luOiAwO1xuICB0cmFuc2Zvcm06IHJvdGF0ZSg5MGRlZyk7XG59XG5cbi5tdWx0aS1tZW51LW92ZXJmbG93LXVwIC5tdWx0aS1tZW51LW92ZXJmbG93LWljb24ge1xuICB0cmFuc2Zvcm06IHJvdGF0ZSgtOTBkZWcpO1xufVxuXG4ubXVsdGktbWVudS1pbm5lci13cmFwcGVyIHtcbiAgcG9zaXRpb246IHJlbGF0aXZlO1xuICB3aWR0aDogMTgwcHg7XG59XG5cbi5tdWx0aS1tZW51LCAubXVsdGktc2VsZWN0LW1lbnUuZXhwYW5kZWQge1xuICBib3gtc2hhZG93OiAwIDAgMCAxcHggcmdiYSgwLCAwLCAwLCAwLjA3KSwgMCA0cHggMTJweCByZ2JhKDAsIDAsIDAsIDAuMik7XG59XG5cbi5tdWx0aS1tZW51LXdyYXBwZXItYXR0YWNoZWQuZXhwYW5kLXVwIC5tdWx0aS1tZW51IHtcbiAgYm94LXNoYWRvdzogMCAwIDAgMXB4IHJnYmEoMCwgMCwgMCwgMC4wNyksIC00cHggMnB4IDZweCByZ2JhKDAsIDAsIDAsIDAuMDcpLCA0cHggMnB4IDZweCByZ2JhKDAsIDAsIDAsIDAuMDcpO1xufVxuXG4ubXVsdGktbWVudS1pdGVtIHtcbiAgcG9zaXRpb246IHJlbGF0aXZlO1xuICBwYWRkaW5nLXJpZ2h0OiAyMHB4O1xuICB1c2VyLXNlbGVjdDogbm9uZTtcbiAgZGlzcGxheTogZmxleDtcbiAgZmxleC1kaXJlY3Rpb246IGNvbHVtbjtcbiAgYWxpZ24taXRlbXM6IHN0cmV0Y2g7XG4gIGp1c3RpZnktY29udGVudDogY2VudGVyO1xuICBjdXJzb3I6IHBvaW50ZXI7XG59XG5cbi5tdWx0aS1tZW51LWl0ZW0ub3BlbiwgLm11bHRpLW1lbnUtaXRlbTpob3ZlciB7XG4gIGJhY2tncm91bmQ6ICMwN2Y7XG4gIGNvbG9yOiAjZmZmO1xuXG4gICYuaGFzLWNoaWxkcmVuOmFmdGVyIHtcbiAgICBiYWNrZ3JvdW5kOiAjZmZmO1xuICB9XG5cbiAgPiAubXVsdGktbWVudS1pdGVtLWxhYmVsIHtcbiAgICA+IC5tdWx0aS1tZW51LWl0ZW0tc3VidGl0bGUge1xuICAgICAgY29sb3I6ICNmZmY7XG4gICAgfVxuICB9XG59XG5cbi5tdWx0aS1tZW51LWl0ZW0uZGlzYWJsZWQge1xuICBjb2xvcjogIzlhOWE5YTtcbiAgcG9pbnRlci1ldmVudHM6IG5vbmU7XG59XG5cbi5tdWx0aS1tZW51LWl0ZW0tbGFiZWwge1xuICB3aGl0ZS1zcGFjZTogbm93cmFwO1xuICBvdmVyZmxvdzogaGlkZGVuO1xuICB0ZXh0LW92ZXJmbG93OiBlbGxpcHNpcztcbiAgcGFkZGluZzogMCAwIDAgMTJweDtcblxuICA+IC5tdWx0aS1tZW51LWl0ZW0tc3VidGl0bGUge1xuICAgIGZvbnQtc2l6ZTogMC44ZW07XG4gICAgY29sb3I6ICM5NTk1OTU7XG4gICAgbWFyZ2luLWxlZnQ6IDAuNWVtO1xuICB9XG59XG5cbi5tdWx0aS1tZW51LWl0ZW0uaW5saW5lIC5tdWx0aS1tZW51LWl0ZW0tbGFiZWwge1xuICBmb250LXNpemU6IDAuOGVtO1xufVxuXG4ubXVsdGktbWVudS1pdGVtLmNoaWxkcmVuLW9ubHkgPiAubXVsdGktbWVudS1pdGVtLWxhYmVsIHtcbiAgY3Vyc29yOiBkZWZhdWx0O1xufVxuXG4ubXVsdGktc2VsZWN0LW1lbnUtZXhwYW5kLWljb246YmVmb3JlIHtcbiAgdHJhbnNmb3JtOiByb3RhdGUoOTBkZWcpO1xuICByaWdodDogMTJweDtcbn1cblxuLm11bHRpLW1lbnUtdHJpZ2dlci5leHBhbmRlZCAubXVsdGktc2VsZWN0LW1lbnUtZXhwYW5kLWljb246YmVmb3JlIHtcbiAgdHJhbnNmb3JtOiByb3RhdGUoMjcwZGVnKTtcbn1cblxuLm11bHRpLW1lbnUtY2hpbGQge1xuICBwb3NpdGlvbjogYWJzb2x1dGU7XG4gIGxlZnQ6IDEwMCU7XG4gIG1hcmdpbi1sZWZ0OiAycHg7XG4gIHRvcDogMDtcbiAgbWFyZ2luLXRvcDogLThweDtcbn1cblxuLm11bHRpLW1lbnUtd3JhcHBlci5leHBhbmQtbGVmdCAubXVsdGktbWVudS1jaGlsZCB7XG4gIHJpZ2h0OiAxMDAlO1xuICBsZWZ0OiBhdXRvO1xuICBtYXJnaW4tcmlnaHQ6IDJweDtcbiAgbWFyZ2luLWxlZnQ6IDA7XG59XG5cbi5tdWx0aS1tZW51LXRyaWdnZXItZWxlbWVudCB7XG4gIGN1cnNvcjogcG9pbnRlcjtcbiAgcG9zaXRpb246IHJlbGF0aXZlO1xufVxuXG4ubXVsdGktbWVudS10cmlnZ2VyIHtcbiAgcG9zaXRpb246IHJlbGF0aXZlO1xuICB1c2VyLXNlbGVjdDogbm9uZTtcbn1cblxuLm11bHRpLW1lbnUtdHJpZ2dlci5leHBhbmRlZDpiZWZvcmUsXG4ubXVsdGktbWVudS10cmlnZ2VyLmV4cGFuZGVkOmFmdGVyIHtcbiAgY29udGVudDogJyc7XG4gIGRpc3BsYXk6IGJsb2NrO1xuICBwb3NpdGlvbjogYWJzb2x1dGU7XG4gIGxlZnQ6IDUwJTtcbiAgdG9wOiAxMDAlO1xuICBtYXJnaW4tdG9wOiAzcHg7XG4gIG1hcmdpbi1sZWZ0OiAtNXB4O1xuICBib3JkZXI6IDVweCBzb2xpZCB0cmFuc3BhcmVudDtcbiAgYm9yZGVyLXRvcDogbm9uZTtcbiAgYm9yZGVyLWJvdHRvbS1jb2xvcjogI2Y1ZjVmNTtcbiAgei1pbmRleDogOTk5OTk7XG59XG5cbi5tdWx0aS1tZW51LXRyaWdnZXIuZXhwYW5kZWQ6YmVmb3JlIHtcbiAgYm9yZGVyLXdpZHRoOiA2cHg7XG4gIGJvcmRlci1ib3R0b20tY29sb3I6IHJnYmEoMCwgMCwgMCwgMC4xNSk7XG4gIG1hcmdpbi10b3A6IDJweDtcbiAgbWFyZ2luLWxlZnQ6IC02cHg7XG59XG5cbi5tdWx0aS1tZW51LXRyaWdnZXIuZXhwYW5kLXVwLmV4cGFuZGVkOmJlZm9yZSxcbi5tdWx0aS1tZW51LXRyaWdnZXIuZXhwYW5kLXVwLmV4cGFuZGVkOmFmdGVyIHtcbiAgZGlzcGxheTogbm9uZTtcbn1cblxuLm11bHRpLW1lbnUtd3JhcHBlciB7XG4gIHBvc2l0aW9uOiBmaXhlZDtcbiAgei1pbmRleDogOTk5OTg7XG59XG5cbi5tdWx0aS1tZW51LXRyaWdnZXItY2xvc2Uge1xuICBwb3NpdGlvbjogZml4ZWQ7XG4gIHotaW5kZXg6IDk5OTk3O1xuICBsZWZ0OiAwO1xuICByaWdodDogMDtcbiAgdG9wOiAwO1xuICBib3R0b206IDA7XG59XG5cbi5tdWx0aS1tZW51LXRyaWdnZXIuZXhwYW5kZWQgLm11bHRpLW1lbnUtdHJpZ2dlci1lbGVtZW50IHtcbiAgei1pbmRleDogOTk5OTg7XG59XG5cbi5tdWx0aS1tZW51LXRyaWdnZXIuYWxpZ24tbGVmdCAubXVsdGktbWVudS13cmFwcGVyIHtcbiAgbGVmdDogMDtcbn1cblxuLm11bHRpLW1lbnUtdHJpZ2dlci5hbGlnbi1yaWdodCAubXVsdGktbWVudS13cmFwcGVyIHtcbiAgcmlnaHQ6IDA7XG59XG5cbi5tdWx0aS1tZW51LXRyaWdnZXIuYWxpZ24tY2VudGVyIC5tdWx0aS1tZW51LXdyYXBwZXIge1xuICBsZWZ0OiA1MCU7XG4gIG1hcmdpbi1sZWZ0OiAtOTBweDtcbn1cblxuLm11bHRpLW1lbnUtc3BhY2VyIHtcbiAgbWFyZ2luOiAxMHB4IDA7XG4gIGJvcmRlci10b3A6IDFweCBzb2xpZCByZ2JhKDAsIDAsIDAsIDAuMSk7XG59XG5cbi5tdWx0aS1zZWxlY3QtbWVudSB7XG4gIGJvcmRlci1yYWRpdXM6IDZweDtcbiAgaGVpZ2h0OiBjYWxjKDEuMmVtICsgMjBweCk7XG59XG5cbi5tdWx0aS1zZWxlY3QtbWVudS5tdWx0aS1tZW51LXRyaWdnZXIuZXhwYW5kZWQ6YmVmb3JlLFxuLm11bHRpLXNlbGVjdC1tZW51Lm11bHRpLW1lbnUtdHJpZ2dlci5leHBhbmRlZDphZnRlciB7XG4gIGRpc3BsYXk6IG5vbmU7XG59XG5cbi5tdWx0aS1zZWxlY3QtbWVudS1zZWxlY3Rpb24ge1xuICBiYWNrZ3JvdW5kOiAjZjVmNWY1O1xuICBjb2xvcjogIzQ0NDtcbiAgcGFkZGluZzogMTBweCAzNXB4IDEwcHggMTJweDtcbiAgYm9yZGVyLXJhZGl1czogNnB4O1xuICBwb3NpdGlvbjogcmVsYXRpdmU7XG4gIGJveC1zaGFkb3c6IGluc2V0IDAgMCAwIDFweCByZ2JhKDAsIDAsIDAsIDAuMSk7XG4gIGxpbmUtaGVpZ2h0OiAxLjJlbTtcbiAgcG9zaXRpb246IGFic29sdXRlO1xuICBsZWZ0OiAwO1xuICByaWdodDogMDtcbiAgdG9wOiAwO1xufVxuXG4ubXVsdGktc2VsZWN0LW1lbnUuZXhwYW5kZWQgLm11bHRpLXNlbGVjdC1tZW51LXNlbGVjdGlvbiB7XG4gIGJveC1zaGFkb3c6IG5vbmU7XG59XG5cbi5tdWx0aS1zZWxlY3QtbWVudS12YWx1ZSB7XG4gIGRpc3BsYXk6IGJsb2NrO1xuICB3aGl0ZS1zcGFjZTogbm93cmFwO1xuICBvdmVyZmxvdzogaGlkZGVuO1xuICB0ZXh0LW92ZXJmbG93OiBlbGxpcHNpcztcblxuICAubXVsdGktc2VsZWN0LW1lbnUtdmFsdWUtc3VidGl0bGUge1xuICAgIGZvbnQtc2l6ZTogMC44ZW07XG4gICAgY29sb3I6ICM5NTk1OTU7XG4gICAgbWFyZ2luLWxlZnQ6IDAuNWVtO1xuICB9XG59XG5cbi5tdWx0aS1zZWxlY3QtbWVudS5leHBhbmQtZG93bi5leHBhbmRlZCAubXVsdGktc2VsZWN0LW1lbnUtc2VsZWN0aW9uIHtcbiAgYm9yZGVyLWJvdHRvbS1sZWZ0LXJhZGl1czogMDtcbiAgYm9yZGVyLWJvdHRvbS1yaWdodC1yYWRpdXM6IDA7XG59XG5cbi5tdWx0aS1zZWxlY3QtbWVudS5leHBhbmQtdXAuZXhwYW5kZWQgLm11bHRpLXNlbGVjdC1tZW51LXNlbGVjdGlvbiB7XG4gIGJvcmRlci10b3AtbGVmdC1yYWRpdXM6IDA7XG4gIGJvcmRlci10b3AtcmlnaHQtcmFkaXVzOiAwO1xufVxuXG4ubXVsdGktbWVudS13cmFwcGVyLWF0dGFjaGVkLmV4cGFuZC1kb3duID4gLm11bHRpLW1lbnUtaW5uZXItd3JhcHBlciA+IC5tdWx0aS1tZW51IHtcbiAgYm9yZGVyLXRvcC1sZWZ0LXJhZGl1czogMDtcbiAgYm9yZGVyLXRvcC1yaWdodC1yYWRpdXM6IDA7XG4gIG1hcmdpbi10b3A6IC0xcHg7XG59XG5cbi5tdWx0aS1tZW51LXdyYXBwZXItYXR0YWNoZWQuZXhwYW5kLXVwID4gLm11bHRpLW1lbnUtaW5uZXItd3JhcHBlciA+IC5tdWx0aS1tZW51IHtcbiAgYm9yZGVyLWJvdHRvbS1sZWZ0LXJhZGl1czogMDtcbiAgYm9yZGVyLWJvdHRvbS1yaWdodC1yYWRpdXM6IDA7XG4gIG1hcmdpbi1ib3R0b206IC0xcHg7XG59XG5cbi5tdWx0aS1tZW51LXdyYXBwZXItYXR0YWNoZWQgPiAubXVsdGktbWVudS1pbm5lci13cmFwcGVyOmJlZm9yZSB7XG4gIGNvbnRlbnQ6ICcnO1xuICBkaXNwbGF5OiBibG9jaztcbiAgcG9zaXRpb246IGFic29sdXRlO1xuICB0b3A6IC00cHg7XG4gIGxlZnQ6IDA7XG4gIHJpZ2h0OiAwO1xuICBoZWlnaHQ6IDRweDtcbiAgYmFja2dyb3VuZDogI2Y1ZjVmNTtcbiAgei1pbmRleDogMTtcbn1cblxuLm11bHRpLW1lbnUtd3JhcHBlci1hdHRhY2hlZC5leHBhbmQtdXAgPiAubXVsdGktbWVudS1pbm5lci13cmFwcGVyOmJlZm9yZSB7XG4gIHRvcDogYXV0bztcbiAgYm90dG9tOiAtNnB4O1xuICBoZWlnaHQ6IDdweDtcbn1cblxuLm11bHRpLXNlbGVjdC1tZW51Lm11bHRpLW1lbnUtdHJpZ2dlci5leHBhbmRlZDphZnRlciB7XG4gIGRpc3BsYXk6IG5vbmU7XG59XG5cbi5tdWx0aS1zZWxlY3QtbWVudS1wbGFjZWhvbGRlciwgLm11bHRpLW1lbnUtZW1wdHkge1xuICBjb2xvcjogIzlhOWE5YTtcbn1cblxuLm11bHRpLW1lbnUtZW1wdHkge1xuICBwYWRkaW5nOiAwIDEycHg7XG59XG5cbiJdfQ== */


### PR DESCRIPTION
This fixes an issue where items in the menu that have `.children-only` class would show `cursor: pointer` on the top and bottom of the item. 

Line `166` is the change I did, everything else is just formatting