### PR TITLE
Adds a boolean option for icons for empty wrappers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -578,9 +578,22 @@ const getIcon = icon => {
     return null
   }
 
-  const iconBody = typeof icon === 'string'
-    ? <span className={classNames('icon', `icon-${icon}` )} />
-    : icon
+  let iconBody;
+
+  switch(typeof icon) {
+    // string name of the icon, for basic icons
+    case 'string':
+      iconBody = <span className={classNames('icon', `icon-${icon}` )} />
+      break
+    // boolean true, for empty icons
+    // does not render an icon, but indents the label as though there was an icon before it
+    case 'boolean':
+      iconBody = ''
+      break
+    // JSX object, for more complicated/customized icons
+    default:
+      iconBody = icon
+  }
 
   return <div className="multi-menu-item-icon">{iconBody}</div>
 }


### PR DESCRIPTION
## Problem
We have compound field types (`Image` and `File`) that have primitive properties. These field types are often not clickable themselves, but they are among clickable field types, which have icons. This can look weird:
<img width="538" alt="Screen Shot 2021-05-20 at 11 44 45 AM" src="https://user-images.githubusercontent.com/20466869/119017877-162dd200-b961-11eb-86a8-0a0a218db855.png">

## Solution
Indent these compound field types to be in-line with the labels of the primitive field types, but without icons:
<img width="555" alt="Screen Shot 2021-05-20 at 11 43 40 AM" src="https://user-images.githubusercontent.com/20466869/119017980-3198dd00-b961-11eb-95fd-ccde14b92d04.png">

## Implementation
I am adding an `icon` property for `Submenu` objects and I am passing in the boolean `true` to render the icon `<div>` wrapper, but without an icon body inside of it. This indents the label in-line with other menu items that do have icons. The `getIcon` function is "overloaded" (to the best of JavaScript's ability) to accept strings, booleans and JSX objects.

Leveraging the `icon` property and then checking its type (instead of adding a brand new option to `Submenu` objects) will allow us to more easily add actual icons to submenus and indent icon-less menu options, if we chose to in the future.