### PR TITLE
Apply HTML title attribute correctly

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -163,9 +163,10 @@ export default class MultiSelectMenu extends Component {
       rowHeight,
       childWidth,
       menuTheme,
+      label,
     } = this.props
 
-    let title = typeof label === 'string' ? label : undefined
+    const title = typeof label === 'string' ? label : this.getLabel()
 
     return (
       <MultiMenuTrigger


### PR DESCRIPTION
## Problem
There is no HTML `title` tooltip in certain contexts, which can make certain things inaccessible/unreadable/confusing:
<img width="532" alt="Screen Shot 2021-05-28 at 5 14 11 PM" src="https://user-images.githubusercontent.com/20466869/120046607-26385800-bfd8-11eb-9ebb-254c3820f296.png">

## Solution
Use either the `label` prop or the `getLabel` prop to apply the HTML `title` attribute:
<img width="805" alt="Screen Shot 2021-05-28 at 4 43 08 PM" src="https://user-images.githubusercontent.com/20466869/120046576-1751a580-bfd8-11eb-88b2-7f57e8aeea55.png">

<img width="718" alt="Screen Shot 2021-05-28 at 5 16 56 PM" src="https://user-images.githubusercontent.com/20466869/120046783-8a5b1c00-bfd8-11eb-9dab-2e993468b98f.png">

## Developer Notes
This never worked because we never accessed `label` off of `props`. Typically, using a variable without a definition would throw a console error and/or there would be a compilation error. However, using the `typeof` operator with an undefined variable just returns `undefined` and masks the fact that the variable was never declared in the first place. This PR now retrieves `label` and also adds a fallback option in case `label` is not passed in.
