### PR TITLE
Add Support for Titles

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -683,7 +683,14 @@ export class MenuItem extends Component {
     
     const childrenOnly = !isClickable && hasSubmenu
     const disabled = !isClickable && !hasSubmenu
-    const title = typeof data.label === 'string' ? data.label : undefined
+
+    let title
+
+    if (data.title) {
+      title = data.title
+    } else if (typeof data.label === 'string') {
+      title = data.label
+    }
 
     return (
       <div


### PR DESCRIPTION
## Problem
The title (that appears on hover over a menu item) is the same as the label. There are times when we want the title to be different than the label.

## Solution
Add support for a `title` property on the passed-in data; if it exists, use that for the title of the menu item.