### PR TITLE
Add support for custom data set attributes on flyout options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -868,7 +868,6 @@ export class MultiMenuTrigger extends Component {
   }
 
   handleBlur = () => {
-    return
     const { handleToggle } = this.props
     this.setState({ expanded: false })
     if (handleToggle) handleToggle(false)

--- a/src/index.js
+++ b/src/index.js
@@ -692,6 +692,14 @@ export class MenuItem extends Component {
       title = data.label
     }
 
+    // Adds HTML data set properties
+    const dataset = {}
+    if (data.dataset) {
+      for (const [key, value] of Object.entries(data.dataset)) {
+        dataset[`data-${key}`] = value
+      }
+    }
+
     return (
       <div
         className={classNames(
@@ -710,6 +718,7 @@ export class MenuItem extends Component {
         onMouseOver={this.handleHover}
         onClick={this.handleClick}
         style={styles}
+        {...dataset}
       >
         <div
           className="multi-menu-item-label"
@@ -859,6 +868,7 @@ export class MultiMenuTrigger extends Component {
   }
 
   handleBlur = () => {
+    return
     const { handleToggle } = this.props
     this.setState({ expanded: false })
     if (handleToggle) handleToggle(false)


### PR DESCRIPTION
We want to track clicks on specific flyout options. To do, we'll start passing in a `dataset` object that can contain one or more properties that will be converted to an HTML [dataset](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/dataset).