### PR TITLE
Fix unsafe warning in frontend by using componentDidMount instead of componentWillMount

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -878,7 +878,7 @@ export class MultiMenuTrigger extends Component {
 
   elementRef = el => (this.element = el)
 
-  componentWillMount() {
+  componentDidMount() {
     window.addEventListener('blur', this.handleBlur)
   }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/18559697/175749770-b9611715-42b0-46b4-9b78-d4a2b537d9b1.png)
