### PR TITLE
[Typescript] - Prevent.default was preventing scrolling once an item was selected in the sidebar

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"
   },
-  "author": "Jeremy Blalock",
+  "author": "AdaloHQ",
   "license": "ISC",
   "dependencies": {
     "classnames": "^2.2.5",
-    "react-document-events": "^1.3.2"
+    "react-document-events": "1.5.1"
   },
   "peerDependencies": {
     "react": ">=16",

--- a/src/index.js
+++ b/src/index.js
@@ -858,10 +858,6 @@ export class MultiMenuTrigger extends Component {
     if (handleToggle) handleToggle(false)
   }
 
-  handleScroll = e => {
-    e.preventDefault()
-  }
-
   handleKeyDown = e => {
     const { handleToggle } = this.props
     if (e.which === ESC) {
@@ -915,12 +911,7 @@ export class MultiMenuTrigger extends Component {
         onDoubleClick={stopPropagation}
         onMouseUp={stopPropagation}
       >
-        {expanded ? (
-          <DocumentEvents
-            onWheel={this.handleScroll}
-            onKeyDown={this.handleKeyDown}
-          />
-        ) : null}
+        {expanded ? <DocumentEvents onKeyDown={this.handleKeyDown} /> : null}
         {expanded ? (
           <MenuPortal>
             <div


### PR DESCRIPTION
# Problem
`frontend` didn't have Typescript support and when it was added, the sidebar would not be scrollable after changing an item with the dropdown. In the gif below, I scroll after selecting a value from the dropdown but nothing happens.

![2022-09-21 19 21 26](https://user-images.githubusercontent.com/18559697/191637748-d3754492-4119-4f1b-b8a3-79c5d909e21a.gif)


# Solution
Removed `prevent.default` from the scrolling behavior of the library.

![2022-09-21 19 10 08](https://user-images.githubusercontent.com/18559697/191637102-97e8f517-c9ff-48e8-bbff-60b76a89df81.gif)

## Related PRs
- [frontend #1548](https://github.com/AdaloHQ/frontend/pull/1548/)

## Libraries Updated
[react-document-events](https://www.npmjs.com/package/react-document-events) -> `1.5.1`
